### PR TITLE
Gentoo support added by Dan Molik dan@d3fy.net 2014-09-03

### DIFF
--- a/cwtool
+++ b/cwtool
@@ -6,6 +6,9 @@
 # author:  James Hunt <james@niftylogic.com>
 # created: 2014-05-20
 #
+# author:  Dan Molik <dan@d3fy.net>
+# updated: 2014-09-03
+#
 
 # USAGE: cwtool <action> [arguments]
 #
@@ -40,6 +43,10 @@ if test -x "/usr/bin/dpkg-query" \
 elif test -x "/bin/rpm" \
   && test -x "/usr/bin/yum"; then
 	AUTO_PKG=redhat
+
+elif test -x "/usr/bin/emerge" \
+  && test -x "/usr/bin/eix"; then
+	AUTO_PKG=gentoo
 fi
 
 AUTO_SVC=undetermined
@@ -49,7 +56,11 @@ if test -x "/usr/sbin/invoke-rc.d" \
 
 elif test -x "/sbin/chkconfig"; then
 	AUTO_SVC=redhat
+
+elif test -x "/sbin/rc-update"; then
+	AUTO_SVC=gentoo
 fi
+
 
 #################################################################
 
@@ -230,6 +241,100 @@ on_redhat () {
 
 #################################################################
 
+on_gentoo () {
+	export CLEAN_DELAY=0
+
+	case $ACTION in
+	pkg-version)
+		NAME=$1
+		/usr/bin/eix -I -q -e "$NAME"
+		if [ $? -ne 0 ]; then
+			exit $?
+		else
+			/usr/bin/eix -e "$NAME" --format '<installedversions:NAMEVERSION>' | sed -e 's,'"$NAME-"',,'
+			exit 0
+		fi
+		;;
+	pkg-latest)
+		NAME=$1
+		/usr/bin/eix-sync -q
+		/usr/bin/eix -q -e "$NAME"
+		exit $?
+		;;
+	pkg-install)
+		NAME=$1
+		VERSION=$2
+		if [ "x$VERSION" = "xlatest" ]; then
+			/usr/bin/eix -n -q -e "$NAME" -! -u
+			if [ $? -ne 0 ]; then
+				/usr/bin/emerge -q "$NAME"
+				exit $?
+			fi
+			/usr/bin/eix -n -q -e "$NAME" -I
+			if [ $? -ne 0 ]; then
+				/usr/bin/emerge -q "$NAME"
+				exit $?
+			fi
+			exit $?
+		else
+			# specific version
+			P_VERSION=$(/usr/bin/eix -n -e "$NAME" --format '<installedversions:NAMEVERSION>' | sed -e 's,'"$NAME-"',,')
+			if [ "$P_VERSION" != "$VERSION" ]; then
+				/usr/bin/emerge -q "$NAME-$VERSION"
+			fi
+			exit $?
+		fi
+		;;
+	pkg-remove)
+		NAME=$1
+		/usr/bin/eix -n -q -e "$NAME" -! -I
+		if [ $? -ne 0 ]; then
+			/usr/bin/emerge -q -C "$NAME"
+		fi
+		exit $?
+		;;
+
+	svc-run-status)
+		NAME=$1
+		/sbin/service $NAME status
+		exit $?
+		;;
+	svc-boot-status)
+		NAME=$1
+		/sbin/rc-update | /bin/grep -q "$NAME"
+		exit $?
+		;;
+	svc-init)
+		NAME=$1
+		VERB=$2
+		if test "x$NAME" = "xcogd" && test "x$VERB" = "xrestart" && test "x$COGD" != "x"; then
+			touch /var/lock/cogd/.needs-restart
+		else
+			/sbin/service $NAME $VERB
+		fi
+		exit $?
+		;;
+	svc-init-force)
+		NAME=$1
+		VERB=$2
+		/sbin/service $NAME $VERB
+		exit $?
+		;;
+	svc-enable)
+		NAME=$1
+		/sbin/rc-update add "$NAME"
+		exit $?
+		;;
+	svc-disable)
+		NAME=$1
+		/sbin/rc-update del "$NAME"
+		exit $?
+		;;
+	esac
+}
+
+#################################################################
+
 if [ "x$ACTION" = "xidentify" ]; then
 	echo "$AUTO_SVC (services)"
 	echo "$AUTO_PKG (packaging)"
@@ -242,6 +347,9 @@ debian)
 	;;
 redhat)
 	on_redhat "$@"
+	;;
+gentoo)
+	on_gentoo "$@"
 	;;
 *)
 	# unknown flavor


### PR DESCRIPTION
Cwtool changes made to autodetect portage, eix, and openrc.
Extensive use of eix to limit the invocation emerge, as traversing
the package tree is expensive.

All cwtool functions have been implemented. The pkg-latest function
will need upstream support to query remote repositories.
